### PR TITLE
Add TUI clipboard copy and filename validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Clipboard Copy for Claude Prompt** (TUI)
+  - Press `c` after fetching a job posting to copy a complete Claude prompt to clipboard
+  - Prompt includes full `ghosted context` output (CV, applications, postings)
+  - Prompt includes the fetched job posting content
+  - Prompt includes instructions for generating tailored resume and cover letter
+  - macOS only (uses `pbcopy`)
+
+- **Filename Validation for Fetched Postings**
+  - Validates generated filenames to reject IDs (numeric, UUID, hex hashes)
+  - Better error messages with example usage when filename generation fails
+  - Improved hostname extraction for company names from job board URLs
+  - 8 new tests for filename validation
+
 - **Microsoft Careers Fetcher** ([#18](https://github.com/celloopa/ghosted/issues/18))
   - Added specialized extractor for `careers.microsoft.com` and `apply.careers.microsoft.com`
   - Parses job data from Next.js `__NEXT_DATA__` JSON embedded in page

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Multi-Agent Document Generation Pipeline - Progress Tracker
 
-> **Last Updated:** 2026-01-16 (Microsoft fetcher #18 completed)
+> **Last Updated:** 2026-01-16 (TUI clipboard copy + filename validation)
 > **Project:** ghosted
 > **Kanban Project ID:** `b666852b-0ef9-4ee0-8d91-a7f341697897`
 > **GitHub Repo:** `celloopa/ghosted`
@@ -349,6 +349,51 @@ Replace Claude API calls with local model inference:
 ---
 
 ## Completed Work Log
+
+### 2026-01-16: TUI Clipboard Copy for Claude Prompt
+
+Added ability to copy a complete Claude prompt to clipboard after fetching a job posting in the TUI.
+
+**Problem solved:** After fetching a posting in the TUI, users had to manually copy content and construct a prompt for Claude. This was tedious.
+
+**Files modified:**
+- `internal/tui/fetch.go` - Added `PostingContent` field, `Result()` getter, 'c' key handler, help text
+- `internal/tui/keys.go` - Added `CopyContext` key binding
+- `internal/tui/app.go` - Added `handleCopyContext()` and `buildApplyPrompt()` functions
+
+**Features:**
+- Press 'c' after successful job posting fetch to copy prompt
+- Runs `ghosted context` to include full context (CV, applications, postings)
+- Includes the fetched job posting content
+- Includes instructions for generating tailored resume and cover letter
+- Shows success message "Claude prompt copied to clipboard"
+
+---
+
+### 2026-01-16: Filename Validation for Fetched Postings
+
+Improved filename generation for fetched job postings to reject IDs and provide better error messages.
+
+**Problem solved:** Some job board URLs (especially LinkedIn) generate filenames that are just numeric IDs, which aren't useful for organizing postings.
+
+**Files modified:**
+- `internal/fetch/fetcher.go` - Added validation functions and improved hostname extraction
+- `internal/fetch/fetcher_test.go` - 8 new tests for filename validation
+- `main.go` - Better error messages with example usage
+
+**Functions added:**
+- `isHexString()` - Checks if string is hexadecimal
+- `looksLikeID()` - Detects numeric, UUID, or hex hash patterns
+- `ValidateFilename()` - Validates generated filenames
+- `extractCleanHostname()` - Extracts company name from hostname
+
+**Test coverage:**
+- `TestLooksLikeID` - ID pattern detection
+- `TestValidateFilename` - Filename validation
+- `TestExtractCleanHostname` - Hostname parsing
+- `TestGenerateFilename_Validation` - Integration tests
+
+---
 
 ### 2026-01-16: Microsoft Careers Site Fetcher (#18)
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -37,7 +37,8 @@ type KeyMap struct {
 	Clear  key.Binding
 
 	// Fetch
-	Fetch key.Binding
+	Fetch       key.Binding
+	CopyContext key.Binding
 
 	// General
 	Help key.Binding
@@ -152,6 +153,10 @@ func DefaultKeyMap() KeyMap {
 		Fetch: key.NewBinding(
 			key.WithKeys("f"),
 			key.WithHelp("f", "fetch"),
+		),
+		CopyContext: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "copy context"),
 		),
 
 		// General

--- a/main.go
+++ b/main.go
@@ -531,7 +531,11 @@ func fetchJobPosting(urlArg string, outputName string) {
 
 	result, err := f.Fetch(urlArg, outputName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error fetching URL: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		// Check if this is a filename generation error and provide example
+		if strings.Contains(err.Error(), "--output") {
+			fmt.Fprintf(os.Stderr, "\nExample:\n  ghosted fetch --output company-position %s\n", urlArg)
+		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
- **TUI Clipboard Copy**: Press `c` after fetching a job posting to copy a complete Claude prompt to clipboard
- **Filename Validation**: Improved filename generation to reject IDs and provide better error messages

## Changes

### TUI Clipboard Copy
- Added `PostingContent` field to `FetchResultDisplay` to store fetched content
- Added `Result()` getter and `CopyContext` key binding
- Added `handleCopyContext()` method that runs `ghosted context` and builds a Claude prompt
- Shows help text for 'c' key option after successful job posting fetch

### Filename Validation
- Added `isHexString()`, `looksLikeID()`, `ValidateFilename()` functions
- Added `extractCleanHostname()` for better company name extraction from URLs
- Better error messages in main.go with example usage
- 8 new tests for filename validation

## Test plan
- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./...`
- [ ] Manual test: Run TUI, fetch a job posting, press 'c', verify clipboard contains Claude prompt
- [ ] Manual test: Try fetching a URL that would generate an ID-like filename, verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)